### PR TITLE
fix: Update to use the new golang based version of asdf

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,8 +12,12 @@ inputs:
     description: Used to set ASDF_DIR, asdf installation dir & path export
     required: false
   asdf-version:
-    default: master
+    default: latest
     description: Used to pin asdf to a release version
+    required: false
+  go-version:
+    default: stable
+    description: Used to pin golang to a release version
     required: false
   cache:
     default: true
@@ -37,13 +41,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
-        path: ${{ inputs.asdf-dir }}
-        ref: ${{ inputs.asdf-version }}
-        repository: asdf-vm/asdf
+        go-version: ${{ inputs.go-version }}
 
     - run: |
+        go install github.com/asdf-vm/asdf/cmd/asdf@${{ inputs.asdf-version }}
         echo 'ASDF_DATA_DIR=${{ inputs.asdf-data-dir }}' >>"${GITHUB_ENV}"
         echo 'ASDF_DIR=${{ inputs.asdf-dir }}' >>"${GITHUB_ENV}"
         echo '${{ inputs.asdf-dir }}/bin' >>"${GITHUB_PATH}"
@@ -71,9 +74,9 @@ runs:
       shell: bash
 
     - if: inputs.cache == 'true' && (
-          inputs.install == 'always' || 
+          inputs.install == 'always' ||
           inputs.sync == 'always' || (
-             (inputs.install == 'auto' || inputs.sync == 'auto') && steps.asdf-cache-restore.outputs.cache-hit != 'true'
+            (inputs.install == 'auto' || inputs.sync == 'auto') && steps.asdf-cache-restore.outputs.cache-hit != 'true'
           )
         )
       uses: actions/cache/save@v4

--- a/asdf-sync
+++ b/asdf-sync
@@ -3,7 +3,7 @@
 #
 # asdf-sync by Rob Zwissler (@robzr) 4/5/2024 https://github.com/robzr/asdf-sync
 
-VERSION=v0.4.3
+VERSION=v0.5.0
 
 SVER_RUN=false
 #### BEGIN SVER
@@ -455,7 +455,7 @@ Constraints:
     < <version_substring> -- less than
     <= <version_substring> -- less than or equal to
     ~> <version_substring> -- pessimistic constraint operator - least significant
-       (rightmost) identifier specified in the constraint matched with >=, but 
+       (rightmost) identifier specified in the constraint matched with >=, but
        more significant (further left) identifiers must be equal
     !pre[release] -- does not contain a prerelease (ie: \"stable\")
     !bui[ild_metadata] -- does not contain build_metadata
@@ -904,25 +904,25 @@ process_tool_versions() {
 print_help() {
   cat <<-_EOF_ 1>&2
 	asdf sync version: ${VERSION}
-	
+
 	ASDF SYNC COMMANDS
 	asdf sync                               Sync .tool-versions plugins (install,
 	                                        optionally update using constraints)
 	asdf sync <name> [<name> ...]           Manually specify package name(s)
 	asdf sync help                          Displays usage instructions
 	asdf sync version                       Displays plugin version
-	
+
 	ASDF SYNC FLAGS
 	asdf sync -f                            Forces installation (suppress error on
 	                                        missing config, overrides conflicts)
 	asdf sync -q                            Quiet output
 	asdf sync -v                            Verbose output
-	
+
 	ASDF SYNC CONFIG
 	Using the same .tool-versions files as asdf (the filename can be overridden
 	with the TOOL_VERSIONS_FILE environment variable, just like asdf), with
 	optional additional tokens embedded in comments. Available tokens:
-	
+
 	sync-constraint="<constraints>"     Uses sver ${SVER_VERSION} constraint syntax
 	                                    sver docs at https://github.com/robzr/sver
 	                                    ex: "v1", ">= 1, < 3.0", "~> v1.2, !pre"


### PR DESCRIPTION
starting with v0.16.0 asdf is now distributed as a go binary instead of a shell script.  As a result, you can no longer install/use asdf by simply cloning the source repo.  

This will instead install golang, install asdf via a go package, then continue.

This breaks compatibility with older asdf.  It also feels rather inefficient to install golang every time, but I'm not sure what an alternative would be.  Perhaps there are some better caching levels that can be added to keep this fast and light.