### PR TITLE
DEVOPS-1003: Unified Dependabot workflow and optimal config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,19 @@
+name: Dependabot
+
+on:
+  pull_request:
+    paths:
+      - .github/dependabot.yaml
+      - .github/workflows/dependabot.yaml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependabot:
+    uses: lovevery-digital/action-dependabot/.github/workflows/dependabot.yaml@v7
+    with:
+      enable_validate: true
+      enable_auto_merge: false
+    secrets: inherit


### PR DESCRIPTION
## Summary
Edge-case migration for `asdf-sync` (github-actions only, previously had config but no workflow).

- Rename `.github/dependabot.yml` → `.github/dependabot.yaml`
- Add validate-only `.github/workflows/dependabot.yaml` caller (`action-dependabot@v7`)
- Optimize github-actions config (limits + group; no cooldown per examples)

## Test plan
- [ ] Dependabot validate workflow passes on this PR

Relates to DEVOPS-997, DEVOPS-1003